### PR TITLE
feat: allow for searching without polish characters

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -38,7 +38,14 @@ const Search = ({ classes, teachers, rooms }: SearchProps) => {
         ? rooms.map((singleRoom) => ({ ...singleRoom, type: 'room' }))
         : [];
       return [...filteredClasses, ...filteredTeachers, ...filteredRooms].filter(
-        (link) => link.name.toLowerCase().includes(value.toLowerCase()),
+        (link) =>
+          link.name.toLowerCase().includes(value.toLowerCase()) ||
+          link.name
+            .toLowerCase()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '') // Match all unicode character modifiers from decomposited string. Example: ś => s (U+0073) + (U+0301)
+            .replace(/\u0142/g, 'l') // Match ł character manually since it doesn't get decomposited into l
+            .includes(value.toLowerCase()),
       );
     }
     return [];

--- a/components/TimeTableAsTable.tsx
+++ b/components/TimeTableAsTable.tsx
@@ -70,15 +70,17 @@ const TimeTableAsTable = ({ timeTable, timeTableList }: Props) => {
     <div className="px-10 pb-16 mt-8">
       <table className="w-full table-fixed border-separate border-0 shadow-lg rounded-lg border-spacing-0 ">
         <thead className="rounded">
-          <tr className="bg-elektronik-red text-white text-sm rounded-t-lg">
-            <th className="py-3 w-10 border border-gray-100/50 rounded-tl-lg">
+          <tr className="text-white text-sm rounded-t-lg">
+            <th className="py-3 w-10 border border-gray-100/50 bg-elektronik-red rounded-tl-lg">
               Nr
             </th>
-            <th className="py-3 w-24 border border-gray-100/50">Godz.</th>
+            <th className="py-3 w-24 border bg-elektronik-red border-gray-100/50">
+              Godz.
+            </th>
             {timeTable.dayNames.map((dayName, index) => (
               <th
                 key={`table-dayName-${dayName}`}
-                className={`py-3 border border-gray-100/50  ${
+                className={`py-3 border bg-elektronik-red border-gray-100/50  ${
                   index === timeTable.dayNames.length - 1 ? 'rounded-tr-lg' : ''
                 }`}
               >


### PR DESCRIPTION
This gives user a ability for searching without need to use Polish characters.

Before:  
![obraz](https://user-images.githubusercontent.com/62100117/195408147-8b5555df-bfb2-4b1f-9361-306bce8b1d25.png)

After:  
![obraz](https://user-images.githubusercontent.com/62100117/195408215-f0f6b12b-4758-4056-b591-dea234da0643.png)

I also stumbled upon a UI issue on Firefox browsers. Basically The background was going outside of border
![obraz](https://user-images.githubusercontent.com/62100117/195408388-f4bf8653-113a-471b-ad06-abd441a6df22.png)
![obraz](https://user-images.githubusercontent.com/62100117/195408414-3059e9fa-4d74-44c1-a69d-7c59fcb19599.png)
