### PR TITLE
improv: avoid pushing initial redirect to history

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -60,9 +60,9 @@ const Layout = ({
           isCorrect = true;
         }
       }
-      if (isCorrect) router.push(parsedPath);
+      if (isCorrect) router.replace(parsedPath);
       else if (timeTableList.classes.length > 0) {
-        router.push(`/class/${timeTableList.classes[0].value}`);
+        router.replace(`/class/${timeTableList.classes[0].value}`);
       }
     }
   }, [


### PR DESCRIPTION
This PR prevents `"trapping"` user on the page.  
By not pushing initial redirect that happens on `/` route to history, we prevent infinite loop when user wants to go back