### PR TITLE
fix: remove tap highlight from buttons

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,6 +18,10 @@ a {
   text-decoration: none;
 }
 
+button {
+  -webkit-tap-highlight-color: transparent;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -57,8 +61,4 @@ a {
 .dark .react-tooltip {
   background-color: #fff !important;
   color: #404040 !important;
-}
-
-button {
-  -webkit-tap-highlight-color: transparent;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -33,6 +33,7 @@ a {
 .rounded-l-0_18 {
   border-radius: 0.18rem 0 0 0.18rem;
 }
+
 .rounded-r-0_18 {
   border-radius: 0 0.18rem 0.18rem 0;
 }
@@ -42,15 +43,22 @@ a {
   color: #fff !important;
   z-index: 10000 !important;
 }
+
 @media (max-width: 1023.98px) {
   .react-tooltip {
     display: none !important;
   }
 }
+
 .react-tooltip.styles-module_show__2NboJ {
   opacity: 1 !important;
 }
+
 .dark .react-tooltip {
   background-color: #fff !important;
   color: #404040 !important;
+}
+
+button {
+  -webkit-tap-highlight-color: transparent;
 }


### PR DESCRIPTION
> [!NOTE]
> Out of the two browsers I tested (Firefox and Chrome), this issue was present on Chrome only.

# Before:

https://github.com/rico-et22/elektronik-timetable/assets/97523625/d22944e0-d9cb-4316-82bc-c4582f2abcfe

# After:

https://github.com/rico-et22/elektronik-timetable/assets/97523625/6d0c5961-f64d-4e09-a15b-0b17e81762cc