### PR TITLE
hotfix: disable prefetch on viewport to reduce amount of edge requests

### DIFF
--- a/components/LessonHour/CustomLink.tsx
+++ b/components/LessonHour/CustomLink.tsx
@@ -47,7 +47,11 @@ export default function CustomLink({
               replacementData ? 'line-through text-gray-500' : ''
             } ${type === 'teacher' ? 'truncate' : ''}`}
           >
-            <Link href={`/${type}/${data.value}`} className="block truncate">
+            <Link
+              href={`/${type}/${data.value}`}
+              className="block truncate"
+              prefetch={false}
+            >
               {shortName}
             </Link>
           </div>
@@ -56,7 +60,10 @@ export default function CustomLink({
           <div>
             {replacementData.value !== '-1' ? (
               <span className="text-zastepstwo-yellow block truncate">
-                <Link href={`/${type}/${replacementData.value}`}>
+                <Link
+                  href={`/${type}/${replacementData.value}`}
+                  prefetch={false}
+                >
                   {shortReplacementName}
                 </Link>
               </span>

--- a/components/ReplacementsButton.tsx
+++ b/components/ReplacementsButton.tsx
@@ -13,7 +13,7 @@ const ReplacementsButton = () => {
   };
   return (
     <div className="mb-8">
-      <Link href="/replacements" passHref legacyBehavior>
+      <Link href="/replacements" passHref legacyBehavior prefetch={false}>
         <a
           className="bg-gray-600 text-white w-full px-4 py-3 flex justify-between items-center transition-all duration-75 rounded-lg"
           onClick={() => handleLinkClick()}

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -169,6 +169,7 @@ const Search = ({ classes, teachers, rooms }: SearchProps) => {
                   legacyBehavior
                   key={`search-${link.type}-${link.value}`}
                   href={`/${link.type}/${link.value}`}
+                  prefetch={false}
                 >
                   <a
                     id={`link-${index}`}

--- a/components/Selectors/ClassesSelector.tsx
+++ b/components/Selectors/ClassesSelector.tsx
@@ -88,6 +88,7 @@ const ClassesSelector = ({ classes }: ClassesSelectorProps) => {
                   legacyBehavior
                   key={`bottomBar-class-letter-${sortedItem.char}-${item.value}`}
                   href={`/class/${item.value}`}
+                  prefetch={false}
                 >
                   <a
                     className={`mb-2 mx-4 first:pt-4 last:mb-4 block px-1 py-px rounded transition duration-100 hover:bg-blue-100 dark:hover:text-gray-700 ${

--- a/components/Selectors/RoomsSelector.tsx
+++ b/components/Selectors/RoomsSelector.tsx
@@ -111,6 +111,7 @@ const RoomsSelector = ({ rooms }: RoomsSelectorProps) => {
                   legacyBehavior
                   key={`bottomBar-room-letter-${sortedItem.char}-${item.value}`}
                   href={`/room/${item.value}`}
+                  prefetch={false}
                 >
                   <a
                     className={`mb-2 mx-4 first:pt-4 last:mb-4 block px-1 py-px rounded transition duration-100 hover:bg-green-100 dark:hover:text-gray-700 ${

--- a/components/Selectors/TeachersSelector.tsx
+++ b/components/Selectors/TeachersSelector.tsx
@@ -90,6 +90,7 @@ const TeachersSelector = ({ teachers }: TeachersSelectorProps) => {
                   legacyBehavior
                   key={`bottomBar-teacher-letter-${sortedItem.char}-${item.value}`}
                   href={`/teacher/${item.value}`}
+                  prefetch={false}
                 >
                   <a
                     className={`mb-2 mx-4 first:pt-4 last:mb-4 block px-1 py-px rounded transition duration-100 hover:bg-red-100 dark:hover:text-gray-700 ${


### PR DESCRIPTION
Recently the app has been experiencing an overload of Vercel Edge Requests, disproportionate to number of users, overloading the free tier limit. see https://github.com/orgs/vercel/discussions/6640
Disabling prefetching on viewport visibility, but leaving it at hover, should fix the issue.