### PR TITLE
Replacements integration: duplicates fixes and teacher replacements always getting filtered

### DIFF
--- a/helpers/fetchReplacements.ts
+++ b/helpers/fetchReplacements.ts
@@ -13,10 +13,10 @@ import { spaceRegExp } from './sharedVariables';
 
 function parseTeacher(teacherString: string): TeacherInfo {
   const [surname, name] = teacherString.split(spaceRegExp);
-
+  let shortName = name ? name[0] : null;
   return {
     notParsed: teacherString,
-    shortString: name ? `${name}.${surname}` : surname,
+    shortString: shortName ? `${shortName}.${surname}` : surname,
 
     name,
     surname,
@@ -24,9 +24,7 @@ function parseTeacher(teacherString: string): TeacherInfo {
 }
 
 function normalizeApiReplacement(replacement: ApiReplacement): Replacement {
-  const lessonRemoved =
-    replacement.deputy.includes('Uczniowie') ||
-    replacement.deputy.includes('Zastępstwo');
+  const lessonRemoved = (/uczniowie|zast.pstwo/gi).test(replacement.deputy);
   const lessonRemovedReason = lessonRemoved ? replacement.deputy : null;
 
   const [className, ...replacedGroups] = replacement.classgroup;

--- a/helpers/findReplacement.ts
+++ b/helpers/findReplacement.ts
@@ -76,9 +76,21 @@ export default function findReplacement(
       const replacementGroup = replacementLesson.replacedGroups.find(
         (grp) => normalizeGroup(grp) === group
       );
+	  
 
       if (!replacementGroup) return false;
-    }
+    } else {
+		 const teacherShortString = getTeacherDataByCode(timeTableList, teacher)
+        ?.name.split(spaceRegExp)
+        .shift()
+        ?.toLowerCase();
+
+      if (
+        replacementLesson.teacher.shortString.toLowerCase() !==
+        teacherShortString
+      )
+        return false;
+	}
 
     return true;
   });


### PR DESCRIPTION
# First commit
Fixes teachers always getting filtered
## before
<img width="398" height="974" alt="image" src="https://github.com/user-attachments/assets/fa1a1fe1-dd15-4e4a-8675-2a2853740aa3" />

## after
<img width="320" height="959" alt="image" src="https://github.com/user-attachments/assets/6dbeaef6-4266-473b-9f6b-5ddc3cec335e" />

# Second commit
The first one is required for the second one to work.
fixes an issue where one replacement would match to 2 groups.
Ps.  Only god knows why the same room `J306P` is called `J306Prz` in replacements. :angry: 
<img width="384" height="454" alt="image" src="https://github.com/user-attachments/assets/9394722b-8887-4c43-a06a-6ed50b4edcdf" />
> it was matching for both of these lessons before
